### PR TITLE
added use of the term free software throughout

### DIFF
--- a/content/about.html
+++ b/content/about.html
@@ -9,12 +9,12 @@ navtitle: About
   <div class="text-block">
     <h3>
         FOSDEM is a two-day event organised by volunteers to promote the
-        widespread use of open source software.
+        widespread use of open source and free software software.
     </h3>
     <p>
         Taking place in the beautiful city of
         <a href="page:practical/transportation">Brussels (Belgium)</a>, FOSDEM
-        is widely recognised as <q>the best open source conference in Europe</q>.
+        is widely recognised as <q>the best open source and free software conference in Europe</q>.
     </p>
   </div>
 </div>
@@ -24,7 +24,7 @@ navtitle: About
       <h2>What is FOSDEM?<a name="what">&nbsp;</a></h2>
       <p>
         FOSDEM is a free and non-commercial event organised by the community for
-        the community.  The goal is to provide open source software developers
+        the community.  The goal is to provide open source and free software developers
         and communities a place to meet to:
 
         <ul class="info-list">
@@ -32,14 +32,14 @@ navtitle: About
             get in touch with other developers and projects;
           </li>
           <li>
-            be informed about the latest developments in the open source world;
+            be informed about the latest developments in the open source and free software world;
           </li>
           <li>
             attend interesting talks and presentations on various topics by
-            open source project leaders and committers;
+            open source and free software project leaders and committers;
           </li>
           <li>
-            to promote the development and the benefits of open source
+            to promote the development and the benefits of open source and free software
             solutions.
           </li>
         </ul>
@@ -52,7 +52,7 @@ navtitle: About
   <div class="text-block">
     <h2>Developer rooms</h2>
     <p>
-      The FOSDEM team feels it is very important for open source software
+      The FOSDEM team feels it is very important for open source and free software software
       developers around the world to be able to meet in “real life”.
     </p>
     <p>
@@ -87,17 +87,19 @@ navtitle: About
     </p>
 
     <p>
-      For the second year, OSDEM was renamed FOSDEM. And now, many years later,
-      it has grown into the event it is today.
-      We now try to cover a wide spectrum of open source projects, and offer a
-      platform for people to collaborate in the true open source spirit.  Every
-      year, we host more than 5000 developers at the ULB Solbosch campus.
+      For the second year, OSDEM was renamed FOSDEM. And now, many
+      years later, it has grown into the event it is today.  We now
+      try to cover a wide spectrum of open source and free software
+      projects, and offer a platform for people to collaborate in the
+      true open source and free software spirit.  Every year, we host
+      more than 5000 developers at the ULB Solbosch campus.
     </p>
 
     <p>
-      Raphael is no longer the driving force behind FOSDEM. After 7 years of
-      hard work he left the team for new Open Source plans. The FOSDEM flag
-      is now proudly carried by the following people:
+      Raphael is no longer the driving force behind FOSDEM. After 7
+      years of hard work he left the team for new Open Source
+      plans. The FOSDEM flag is now proudly carried by the following
+      people:
     </p>
   </div>
   <div class="text-block">

--- a/content/about.html
+++ b/content/about.html
@@ -9,7 +9,7 @@ navtitle: About
   <div class="text-block">
     <h3>
         FOSDEM is a two-day event organised by volunteers to promote the
-        widespread use of open source and free software software.
+        widespread use of open source and free software.
     </h3>
     <p>
         Taking place in the beautiful city of
@@ -52,7 +52,7 @@ navtitle: About
   <div class="text-block">
     <h2>Developer rooms</h2>
     <p>
-      The FOSDEM team feels it is very important for open source and free software software
+      The FOSDEM team feels it is very important for open source and free software
       developers around the world to be able to meet in “real life”.
     </p>
     <p>

--- a/content/index.html
+++ b/content/index.html
@@ -11,7 +11,7 @@ maxnews = @config.fetch(:news).fetch(:items_on_index_page).to_i
 %>
   <div class="s-block">
     <div class="text-block">
-      <h2>FOSDEM is a free event that offers open source communities a place to meet, share ideas and collaborate.</h2>
+      <h2>FOSDEM is a free event that offers open source and free software communities a place to meet, share ideas and collaborate.</h2>
       <p>It is renowned for being highly developer-oriented and brings together 5000+ geeks from all over the world.</p>
       <p class="btn-news"><a href="page:/about/#what">No registration necessary.</a></p>
     </div>

--- a/layouts/main.html
+++ b/layouts/main.html
@@ -93,6 +93,7 @@ $layout_dateline ||= begin
               'beer' => nil,
               'devrooms' => '/schedule/tracks/',
               'open source' => nil,
+              'free software' => nil,
               '5000+ hackers' => nil,
               'lightning talks' => '/schedule/track/lightning_talks/',
               "#{$eventcount} lectures" => '/schedule/events/',


### PR DESCRIPTION
In the past, the FOSDEM website took a balanced approach to using the terms "free software" and "open source." It seems that the term "free software" was dropped throughout. I have added "free software" throughout the about page to make it clear that the conference represents the ideas and the spirit of the members of the open source and free software community as a whole. 