### PR TITLE
expose some missing pages in the Practical category

### DIFF
--- a/content/navigation.yaml
+++ b/content/navigation.yaml
@@ -30,6 +30,8 @@ footer:
     - /practical/accessibility
     - /practical/accommodation
     - /practical/conduct
+    - /practical/services
+    - /practical/jobcorner
   - Media and press:
     - /interviews
     - Video recordings: 'http://video.fosdem.org/'

--- a/content/practical/index.html
+++ b/content/practical/index.html
@@ -42,12 +42,27 @@ navcat: true
   seating in presentations.
 </p>
 
+<a name="services"></a>
+<h3>Services during FOSDEM</h3>
+<p>
+  There are a number of free services available to visitors during the event, <a
+  href="page:practical/services">see details here.</a>
+</p>
+
 <a name="conduct"></a>
 <h3>Code of Conduct</h3>
 <p>
   In order to keep FOSDEM a fun, interesting and positive experience for
   everybody, we expect participants to follow the
   <a href="page:practical/conduct">FOSDEM Code of Conduct</a>.
+</p>
+
+<a name="jobcorner"></a>
+<h3>Job Corner</h3>
+<p>
+  Some passive recruitment is allowed for open source positions and
+  contracting. See
+  <a href="page:practical/jobcorner">Job Corner</a> for details.
 </p>
 
 <a name="other"></a>


### PR DESCRIPTION
Wasn't sure whether we left these out of the site navigation and Practical index intentionally this year, especially the job corner. If it's not intentional we should include them again.