### PR TITLE
load scripts and styles via HTTPS

### DIFF
--- a/layouts/mobile.html
+++ b/layouts/mobile.html
@@ -3,9 +3,9 @@
     <head> 
         <title><%= conference()[:title] %></title>
         <meta name="viewport" content="width=device-width, initial-scale=1"> 
-        <link rel="stylesheet" href="http://code.jquery.com/mobile/1.2.0/jquery.mobile-1.2.0.min.css" />
-        <script src="http://code.jquery.com/jquery-1.8.2.min.js"></script>
-        <script src="http://code.jquery.com/mobile/1.2.0/jquery.mobile-1.2.0.min.js"></script>
+        <link rel="stylesheet" href="https://code.jquery.com/mobile/1.2.0/jquery.mobile-1.2.0.min.css" />
+        <script src="https://code.jquery.com/jquery-1.8.2.min.js"></script>
+        <script src="https://code.jquery.com/mobile/1.2.0/jquery.mobile-1.2.0.min.js"></script>
         <script type="text/javascript">
             $(document).bind("mobileinit", function() {
                 $.mobile.defaultPageTransition = 'slide';


### PR DESCRIPTION
Otherwise mobile browsers do not load the scripts and a user cannot change it

Even better would be hosting them on fosdem.org itself, but this at least makes it actually usable. Otherwise one only sees a huge list without styles on handhelds.