### PR TITLE
Drop the mention of the current organizing project

### DIFF
--- a/content/schedule/devrooms/microkernels.html
+++ b/content/schedule/devrooms/microkernels.html
@@ -6,10 +6,3 @@ scarce. The microkernel developer room brings the heads behind several
 projects together and offers a chance to get up to speed with
 developments in different groups.
 </p>
-
-<p>
-Organization of the microkernel developer room is done in turns by
-groups in the microkernel community. This year's developer room is
-organized by the <a href="http://www.helenos.org">HelenOS</a>
-developers.
-</p>


### PR DESCRIPTION
Instead of updating this part every year, it can be removed so that this file is always up to date.