### PR TITLE
schedule: add rust devroom description

### DIFF
--- a/content/schedule/devrooms/rust.html
+++ b/content/schedule/devrooms/rust.html
@@ -1,0 +1,11 @@
+<p>
+<a href="https://www.rust-lang.org">Rust</a> is a systems programming language that is focused on safety, speed, and concurrency.
+It is designed to be a practical language with a minimal runtime, empowering developers with zero-cost abstractions,
+guaranteed memory safety, and an expressive type system.
+</p>
+
+<p>
+This track aims to present the features and possibilities offered by
+Rust, as well as some of the many exciting tools and projects in its
+ecosystem.
+</p>


### PR DESCRIPTION
This adds a short description for https://fosdem.org/2018/schedule/track/rust/.