### PR TITLE
Adds Docker support and notes on how to leverage it in the README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,16 @@
-FROM ruby:2.1
+FROM ruby:2.7
 MAINTAINER ryan@slatehorse.com
 
 # Install other dependencies
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -yq \
       pngcrush \
-      imagemagick 
+      imagemagick \
+      krb5-user
 
 # Copy the Gemfile in and bundle, so we have the dependencies cached
 ADD Gemfile .
 ADD Gemfile.lock .
-RUN bundle install
+RUN gem install bundler:1.17.3 && bundle install
 
 # Set encoding to prevent nanoc exploding
 ENV LANG=C.UTF-8

--- a/content/index.html
+++ b/content/index.html
@@ -70,5 +70,5 @@ maxnews = @config.fetch(:news).fetch(:items_on_index_page).to_i
 
   <div class="location-block">
     <h2>LOCATION</h2>
-    <p>To be announced</p>
+    <p>FOSDEM 2022 will take place online.</p>
   </div>


### PR DESCRIPTION
This PR adds the ability to run the site generator in a Docker container. This can be particularly handy to isolate dependencies (e.g. if you don't have ruby 2.1.5 or a version manager installed already).

Running it within Docker isn't mandatory, and does slow down the build, but may be useful for testing upgrades and so forth.