### PR TITLE
Add description for Open Research Tools and Technologies devroom

### DIFF
--- a/content/schedule/devrooms/open_research_tools_and_technologies.html
+++ b/content/schedule/devrooms/open_research_tools_and_technologies.html
@@ -1,0 +1,15 @@
+<p>
+The Open Research Tools and Technologies devroom addresses FLOSS developers in a broad community concerned with research production and curation: scientists, engineers, journalists, archivists, curators, activists.
+The tools and technologies targeted are typically creating, handling or sharing knowledge artifacts: data, academic papers, books, collections, web contents, algorithms, artworks.
+This devroom provides a place and time to discuss the issues related to the creation and usage of open research technologies, with the ambition to foster discussions between designers, developers and users, bridging multiple knowledge-based communities together, and with the broader FLOSS community.
+</p>
+
+<p>
+Our topics include:
+<ul>
+<li><strong>New software releases</strong> of research tools or technologies.</li>
+<li><strong>Feedback</strong> on open technology stacks used in research contexts (e.g., scientific research, journalistic inquiry, archive creation or publication) which collect, analyse, document, visualize, and/or share data.</li>
+<li><strong>Tool design and implementation</strong> for specific research contexts, e.g. how to hold an algorithm accountable to social scientists, how to foster better replicability and interoperability thanks to FLOSS, how to cope with biases of a chart for a data journalist, etc.</li>
+<li>Issues and opportunities about <strong>bridging tech culture with research environments</strong> (research labs, libraries, newsrooms, museums).</li>
+</ul>
+</p>


### PR DESCRIPTION
Note: Room was initially named _Open Source Science and Research Tools_ and has been renamed to _Open Research Tools and Technologies_.