### PR TITLE
Fix small typo in Erlang, Elixir and Friends devroom

### DIFF
--- a/content/devrooms-cfp.yaml
+++ b/content/devrooms-cfp.yaml
@@ -32,8 +32,8 @@ days:
     'Embedded, Mobile and Automotive':
         ann:
         deadline:
-    
-    'Erlang, Elexir and Friends':
+
+    'Erlang, Elixir and Friends':
         ann: https://lists.fosdem.org/pipermail/fosdem/2019q4/002901.html
         deadline: 2019-11-25
     


### PR DESCRIPTION
Thanks for all the hard work in organising FOSDEM! 🇧🇪 

Just fixing a small typo for our Devroom on the BEAM VM, with title "Erlang, [Elixir](https://elixir-lang.org/) and Friends".

Thanks! 🙇 