### PR TITLE
Update Ubuntu Phone app URL

### DIFF
--- a/content/schedule/mobile.html
+++ b/content/schedule/mobile.html
@@ -35,7 +35,7 @@ Ways to have the schedule with you at all times, without wasting trees:
 </li>
 <li><b>Ubuntu Phone: FOSDEM</b><br />
     <a href="https://github.com/delijati/fosdem-qml">Source code</a>,<br />
-    Available from the <a href="https://uappexplorer.com/app/fosdem-qml.delijati">Ubuntu app store</a>.<br />
+    Available from the <a href="https://open-store.io/app/fosdem-qml.delijati">Ubuntu app store</a>.<br />
 </li>
 <li><b>Windows Phone: FOSDEM</b><br />
     <a href="https://github.com/julianls/FOSDEM">Source code</a>,<br />


### PR DESCRIPTION
I don't use a Ubuntu Phone but while downloading a schedule app for Android I opened the other app's websites, out of curiosity.

I noticed that the URL for FOSDEM app on Ubuntu Phone linked to a website which has shutdown since. This pull request amends that.
