### PR TITLE
feat(softare_composition): initial devroom description

### DIFF
--- a/content/schedule/devrooms/software_composition.html
+++ b/content/schedule/devrooms/software_composition.html
@@ -1,0 +1,30 @@
+<p>
+As we all assemble more complex software apps from an ever growing number of free and open source software components, knowing what's in our code is a must for legal, security and operational reasons. Software Composition Analysis (SCA) is the set of techniques to determine which software components we reuse, where and how, as well as their origin, licensing, vulnerabilities, quality and other important attributes.
+Open source SCA tools are emerging as the best way to help determine which FOSS software components are used in a software system or application.
+</p>
+
+<p>
+You are an SCA FOSS tool or project contributor, maintainer, or user? If so, let's meet at FOSDEM 2021 to share our techniques, experiences and bag of tricks and demo or present our FOSS tools to colloborate towards a better SCA FOSS toolchain.
+</p>
+
+<p>
+The devroom looks for in all kinds of presentations about SCA-related topics using Free and Open Source software. Some of the topics include in no particular order:
+</p>
+
+<ul>
+<li>Code origin detection techniques</li>
+<li>Code matching and related code similarity detection</li>
+<li>Static or dynamic binary analysis for provenance and origin</li>
+<li>Source code analysis for provenance and origin</li>
+<li>Package and project metadata collection</li>
+<li>App and distro dependencies discovery</li>
+<li>Container and related whole-distro analysis</li>
+<li>tools producing and consuming a software bill-of-material (SBOM)</li>
+<li>License and copyright detection and analysis</li>
+<li>Open data for SCA (packages, vulnerabilities, licenses, etc.)</li>
+<li>Packages and projects quality metrics</li>
+<li>Vulnerability detection and related security analysis</li>
+<li>License and security compliance and policies</li>
+<li>Various data formats for SCA such as package manifests and SBOM</li>
+<li>New or existing FOSS tool demo for any of the above</li>
+</ul>


### PR DESCRIPTION
Initial commit for adding the description for the `software_composition` devroom.

CFP is here: https://github.com/software-composition-analysis/fosdem-2021-devroom