### PR TITLE
Mention Allow integrations option

### DIFF
--- a/content/practical/online.html
+++ b/content/practical/online.html
@@ -40,6 +40,11 @@ navcat: true
     In each room, you'll see a fairly large widget which will display the video stream. The first time you visit <a href="https://chat.fosdem.org"><i>chat.fosdem.org</i></a>,
     you'll have to click <i>allow</i> so the widget can start playing videos. You can resize the video widget or watch it full screen.
 </p>
+<p>
+    If you don't see widgets in the room, make sure you have allowed integrations in your user settings. This option is enabled by default on
+    <a href="https://chat.fosdem.org"><i>chat.fosdem.org</i></a> and <a href="https://matrix.org"><i>matrix.org</i></a> accounts but
+    it maybe switched off on custom servers.
+</p>
 <img src="/2021/practical/main_conference_screen.png" alt="Room view." aria-labelledby="virtual-room-view" style="max-width: 96%; margin: 2em 2% 0 2%;"/>
 <div id="virtual-room-view" style="margin: .5em 2% 2em 2%; width: 96%;"><i>Room view. 1 is the video window; 2 is the chat window.</i></div>
 <p>


### PR DESCRIPTION
On custom matrix servers integrations may be disabled by default, and widgets won't be available.

Adding a note to point those users to the right option.