### PR TITLE
Add a direct link to chat.fosdem.org from /live

### DIFF
--- a/content/live/index.html
+++ b/content/live/index.html
@@ -13,6 +13,7 @@ title: FOSDEM 2021
       <p class="btn-news"><a href="#devrooms">To the devrooms.</a></p>
       <p class="btn-news"><a href="#stands">To the stands.</a></p>
       <p class="btn-news"><a href="page:schedule">To the schedule.</a></p>
+      <p class="btn-news"><a href="https://chat.fosdem.org/#/home">To the chat.</a></p>        
     </div>
     <div class="container">
             <% keynotes = tracks.select{|t| ['maintrack', 'lightningtalks'].include? t[:type] } %>


### PR DESCRIPTION
So that folks can also view the social chatrooms etc present there.