### PR TITLE
Pearson VUE online exams are Windows and macOS only!

### DIFF
--- a/content/certification.html
+++ b/content/certification.html
@@ -90,6 +90,9 @@ certs = events.select{|e| e[:type] == 'certification'}.sort_by{|e| e[:start_date
   <li>
     Registration is for Pearson VUE vouchers. No in-person sessions will be organised.
   </li>
+  <li>
+    Note: Online exams can only be taken on Windows and macOS computers - check the 
+    <a href="https://home.pearsonvue.com/lpi/onvue?ot=collapse7">technical requirements</a>.
 </ul>
 
 <hr/>


### PR DESCRIPTION
This seems like something really important to note given the typical FOSDEM audience:
> All Linux/Unix based Operating Systems are strictly prohibited.