### PR TITLE
Fix schedule day timetable

### DIFF
--- a/content/assets/style/parts/020_local.css
+++ b/content/assets/style/parts/020_local.css
@@ -169,7 +169,7 @@ q:after { content: "’"; }
 #schedule-grid a.trackref { font-variant: small-caps; font-style: normal !important; }
 
 .timetable {
-    table-layout: fixed;
+    table-layout: auto;
     font-size: xx-small;
 }
 

--- a/layouts/schedule/day.html
+++ b/layouts/schedule/day.html
@@ -17,7 +17,7 @@ rooms = begin
 
 columns = rooms.size + 1 # one more for the time
 
-xml.table(class: "timetable timetable-head table table-striped table-bordered table-condensed") do
+xml.table(class: "timetable timetable-body table table-striped table-bordered table-condensed") do
   xml.thead do
     xml.tr do
       xml.th(class: 'backlink') do
@@ -32,17 +32,6 @@ xml.table(class: "timetable timetable-head table table-striped table-bordered ta
       end
     end #tr
   end #thead
-  # Produce valid XHTML: can't have a table with a thead without a tbody.
-  # And we need the thead or the style breaks violently.
-  xml.tbody do
-    xml.tr do
-      xml.td(style: "display:none;") do
-      end
-    end
-  end
-end #table
-
-xml.table(class: "timetable timetable-body table table-striped table-bordered table-condensed") do
   xml.tbody do
     c = 0
     source.fetch(:by_time).each do |time, by_rooms|


### PR DESCRIPTION
This fixes the issue of day timetables on https://fosdem.org/2021/schedule/day/saturday/ and https://fosdem.org/2021/schedule/day/sunday/ being so condensed to be unreadable.

Result with the patch:
![Screenshot 2021-02-06 at 13 57 31](https://user-images.githubusercontent.com/20153481/107118782-4b675600-6883-11eb-9416-40c2be56dc96.png)


(probably not a really clean solution but it does its job)