### PR TITLE
t-shirts/hoodies: clarify design detail, no drawing on the back

### DIFF
--- a/content/tshirts.html
+++ b/content/tshirts.html
@@ -38,8 +38,8 @@ navtitle: T-shirts
         <h5>T-shirts</h5>
         <img src="asset:t-shirt" alt="2022 T-shirt design." style="max-width: 80%; margin-top: 1em; margin-bottom: 1em;" />
         <p>
-            The t-shirt design this year is grey with the FOSDEM 2022 logo. They're yours in exchange for a donation of
-            €25.
+            The t-shirt design this year is grey with the FOSDEM 2022 logo (without drawing on the back).
+            They're yours in exchange for a donation of €25.
         </p>
         <p>
             T-shirts are available in <i>non-fitted</i> (<i>male</i>) and <i>fitted</i> (<i>female</i>) for in sizes
@@ -52,8 +52,8 @@ navtitle: T-shirts
         <h5>Hoodies</h5>
         <img src="asset:hoodie" alt="2022 hoodie design." style="max-width: 80%; margin-top: 1em; margin-bottom: 1em;" />
         <p>
-            The hoodie design this year is grey with the FOSDEM 2022 logo. They're yours in exchange for a donation of
-            €50.
+            The hoodie design this year is grey with the FOSDEM 2022 logo (without drawing on the back).
+            They're yours in exchange for a donation of €50.
         </p>
         <p>
             Hoodies are available in S, M, L, XL, XXL and XXXL.


### PR DESCRIPTION
**Warning: I actually have no ideas if it's the case :-)**

-----

The images show only the front side of the t-shirts/hoodies, and
some previous FOSDEM t-shirts had drawing on the back.