### PR TITLE
Updated practical/ pages to 2022

### DIFF
--- a/content/practical/matrix_troubleshooting.html
+++ b/content/practical/matrix_troubleshooting.html
@@ -1,8 +1,8 @@
 ---
-title: Troubleshooting Matrix at FOSDEM 2021
+title: Troubleshooting Matrix at FOSDEM 2022
 navcat: true
 ---
-<h3>Troubleshooting Matrix at FOSDEM 2021</h3>
+<h3>Troubleshooting Matrix at FOSDEM 2022</h3>
 <p>
   This year, FOSDEM will use Matrix to host the Q&amp;A sessions after each talk, and chat rooms.
 </p>
@@ -13,14 +13,14 @@ navcat: true
 <a name="nomatrix"></a>
 <h3>Without using Matrix, you can still do the following:</h3>
 <ul>
-<li>View the <a href="https://fosdem.org/2021/live/">live streams</a>. </li>
+<li>View the <a href="https://fosdem.org/2022/live/">live streams</a>. </li>
 <li><a href="#ircinstead">Participate in the Matrix chat rooms via IRC</a>, but some Matrix-specific features can&#39;t be bridged to IRC - e.g. upvoting questions.</li>
 </ul>
 
 <a name="quickstart"></a>
 <h3>Quick Start</h3>
 <p>
-  Whilst there are <a href="https://matrix.org/clients/">many ways</a> to participate in the FOSDEM 2021 Matrix rooms, the most straight-forward should be:
+  Whilst there are <a href="https://matrix.org/clients/">many ways</a> to participate in the FOSDEM 2022 Matrix rooms, the most straight-forward should be:
 </p>
 
 <ul>
@@ -106,5 +106,5 @@ That&#39;s because <a href="https://github.com/vector-im/element-web">Element</a
 <a name="ircinstead"></a>
 <h3>Participating via IRC</h2>
 <p>
-  Most FOSDEM 2021 Matrix rooms are &quot;bridged&quot; to channels on the Libera.Chat IRC network.  e.g. the <code>#infodesk:fosdem.org</code> Matrix room is bridged to the Libera.Chat IRC channel <code>#fosdem-infodesk</code>.  Other Matrix rooms follow the same pattern.  The keynotes stream is currently on IRC as <code>#fosdem-fosdem</code>.
+  Most FOSDEM 2022 Matrix rooms are &quot;bridged&quot; to channels on the Libera.Chat IRC network.  e.g. the <code>#infodesk:fosdem.org</code> Matrix room is bridged to the Libera.Chat IRC channel <code>#fosdem-infodesk</code>.  Other Matrix rooms follow the same pattern.  The keynotes stream is currently on IRC as <code>#fosdem-fosdem</code>.
 </p>

--- a/content/practical/online.html
+++ b/content/practical/online.html
@@ -1,10 +1,10 @@
 ---
-title: FOSDEM 2021 Online
+title: FOSDEM 2022 Online
 navcat: true
 ---
-<h3>FOSDEM 2021 is the first fully online edition of FOSDEM!</h3>
+<h3>FOSDEM 2022 is the second fully online edition of FOSDEM!</h3>
 <p>
-    Welcome to our first online edition. We still have our familiar programme of keynotes, devrooms and stands, but in a slightly different
+    Welcome to our second online edition. We still have our familiar programme of keynotes, devrooms and stands, but in a slightly different
     form. As we can't simply point you to the right room (always a challenge at the ULB), we've provided a lot more extra practical information
     so you can enjoy the conference.
 </p>
@@ -38,7 +38,7 @@ navcat: true
     normally somewhere on the ULB campus, but now fully virtualised. There are two live streams for each room, one with only the video (called
     <i>Video only</i>) and one with Q&A (called <i>Video with Q&A</i>). Both streams will show the same video, so you won't miss a thing.
 </p>
-<img src="/2021/practical/devroom_main_view.png" style="margin: .5em 2% 2em 2%; width: 96%;" alt="Video with Q&A." />
+<img src="/2022/practical/devroom_main_view.png" style="margin: .5em 2% 2em 2%; width: 96%;" alt="Video with Q&A." />
 <p>
     If you want to say things in the chat, you’ll need to sign up for an account (the green <i>Sign up</i> button at the bottom right).
     Alternatively, if you already have an account somewhere on Matrix, you can sign in with that one.
@@ -66,7 +66,7 @@ navcat: true
 <a name="mobile"></a>
 <h5>Notes for mobile users</h5>
 <p>
-    You can attend FOSDEM 2021 on mobile without a problem. However, the <i>Video with Q&A</i> links will not work on a mobile browser. If you
+    You can attend FOSDEM 2022 on mobile without a problem. However, the <i>Video with Q&A</i> links will not work on a mobile browser. If you
     wish to participate in the Q&A, you'll have to click the <i>Join the conversation!</i> link instead. Watching the video feed via <i>Video only</i>
     will always work, as will the <a href="page:live">conference floor page</a>.
 </p>


### PR DESCRIPTION
Some pages in /2022/practical/ were still referencing FOSDEM 2021:
- https://fosdem.org/2022/practical/online/
- https://fosdem.org/2022/practical/matrix_troubleshooting/