### PR TITLE
oniro: Add renamed chatroom

### DIFF
--- a/content/stands-chatroom.yaml
+++ b/content/stands-chatroom.yaml
@@ -25,7 +25,7 @@ stands_chatroom_link:
   ntop: ntop
   onlyoffice: onlyoffice
   openembedded: openembedded
-  openharmony: openharmony_project
+  oniro: oniro_project
   openmandriva: openmandriva
   opentap: opentap
   openuk: openuk


### PR DESCRIPTION
oniro: Rename chatroom to have it listed

At:
https://chat.fosdem.org/#/home

you cannot see Oniro stand.
You can see openharmony and takes you nowhere

Please double check about naming, it should link:

https://stands.fosdem.org/stands/oniro_project/

https://chat.fosdem.org/#/room/#oniroproject:libera.chat

Cc: @toscalix
Forwarded: https://github.com/FOSDEM/website/pull/185
Relate-to: https://github.com/FOSDEM/stands-website/pull/124
Relate-to: https://gitlab.eclipse.org/groups/eclipse-wg/oniro-wg/proposal-incubation-stage-oniro/-/wikis/Events/FOSDEM#stand-wip
Signed-off-by: Philippe Coval <philippe.coval@huawei.com>
