### PR TITLE
fix layout of schedule overview page

### DIFF
--- a/content/assets/style/parts/020_local.css
+++ b/content/assets/style/parts/020_local.css
@@ -499,3 +499,19 @@ pre.sh {
 .name-index-items li:before {
     content: "\00B7\00A0";
 }
+
+@media (max-width: 767px) {
+  /* breakpoint in line with bootstraps "phones to tablets" */
+
+  #main {
+    padding: 18px;
+  }
+
+  .container-fluid .row-fluid [class*="span"] {
+    width: 100%;
+    margin-left: 0;
+  }
+  .container-fluid .row-fluid [class*="span"] ul {
+    margin-bottom: 0;
+  }
+}

--- a/content/schedule.html
+++ b/content/schedule.html
@@ -15,6 +15,8 @@ standtracks = tracks.select{|t| t[:type] == 'standtrack'}.sort_by{|t| [ t[:rank]
 lt_track = tracks.select{|t| t[:type] == 'lightningtalk'}.first
 ltalks = events.select{|e| e[:type] == 'lightningtalk'}.sort_by{|e| e[:start_datetime]}
 certs = events.select{|e| e[:type] == 'certification'}.sort_by{|e| e[:start_datetime]}
+
+columns = 3
 %>
 
 <div class="info-block">
@@ -212,7 +214,6 @@ certs = events.select{|e| e[:type] == 'certification'}.sort_by{|e| e[:start_date
 </p>
 <%
   devrooms_announcement = @items.select{|i| i.identifier =~ %r{^/news/.*accepted-devrooms.*/$}}.first
-  columns = 3
   if not devrooms.empty?
 %>
 <p>
@@ -221,7 +222,7 @@ certs = events.select{|e| e[:type] == 'certification'}.sort_by{|e| e[:start_date
 </p>
 <div class="container-fluid">
     <div class="row-fluid">
-        <% devrooms.sort_by{|x| x[:title]}.each_slice(devrooms.size / columns) do |list| %>
+        <% devrooms.sort_by{|x| x[:title]}.each_slice((devrooms.size / columns).ceil) do |list| %>
         <div class="span<%= 9 / columns %>">
             <ul>
                 <% list.each do |t| %>
@@ -280,7 +281,7 @@ certs = events.select{|e| e[:type] == 'certification'}.sort_by{|e| e[:start_date
 </p>
 <div class="container-fluid">
     <div class="row-fluid">
-        <% standtracks.sort_by{|x| x[:title].downcase}.each_slice(standtracks.size / columns) do |list| %>
+        <% standtracks.sort_by{|x| x[:title].downcase}.each_slice((standtracks.size / columns).ceil) do |list| %>
         <div class="span<%= 9 / columns %>">
             <ul>
                 <% list.each do |t| %>


### PR DESCRIPTION
This contains two commits which
- make sure the bullet point columns for dev rooms and stands on the schedule overview page actually stick to the specified column count
- disregard the columns on mobile screens and shows them as a flat list to improve readability

Before:  
<img src="https://user-images.githubusercontent.com/4174525/152647618-cb21afb5-1020-4bf2-ab1d-e494d3d40045.PNG" width="300px">

After:  
<img src="https://user-images.githubusercontent.com/4174525/152647627-df8c0f2f-db8d-4bb1-aa0d-47ecd891d147.PNG" width="300px">

