### PR TITLE
actually fix column slice for dev rooms and stands list on shedule page

### DIFF
--- a/content/schedule.html
+++ b/content/schedule.html
@@ -16,7 +16,7 @@ lt_track = tracks.select{|t| t[:type] == 'lightningtalk'}.first
 ltalks = events.select{|e| e[:type] == 'lightningtalk'}.sort_by{|e| e[:start_datetime]}
 certs = events.select{|e| e[:type] == 'certification'}.sort_by{|e| e[:start_datetime]}
 
-columns = 3
+columns = 3.0
 %>
 
 <div class="info-block">


### PR DESCRIPTION
second attempt at #187 / fe49981c4b03122bd800a834b7b9df3699cd1432

- make sure the bullet point columns for dev rooms and stands on the schedule overview page actually stick to the specified column count

Thanks ruby :D