### PR TITLE
Streamline naming of CfP to `participation`

### DIFF
--- a/content/news/2022-11-13-call-for-presentations.html
+++ b/content/news/2022-11-13-call-for-presentations.html
@@ -24,7 +24,7 @@ title: 'Presentations - Call for Participation'
 <h3>Developer Rooms</h3>
 
 <p>
-  For more details about the Developer Rooms, please refer to the Calls for Papers that are being added to <a 
+  For more details about the Developer Rooms, please refer to the Calls for Participation that are being added to <a 
 href="page:news/2022-11-07-accepted-developer-rooms">https://fosdem.org/2023/news/2022-11-07-accepted-developer-rooms/</a> when they are issued.
 </p>
 
@@ -92,7 +92,7 @@ Questions or remarks?  Contact us at <a href="mailto:program@fosdem.org">program
 
 <p>
 If the topic fits into a <b>Developer Room</b>, then
-  please refer to that room's call for papers, listed
+  please refer to that room's call for participation, listed
   <a
 href="page:news/2022-11-07-accepted-developer-rooms">here</a>
   and select that room as the "track".
@@ -103,7 +103,7 @@ developer rooms.
 <p>
   Submissions will be reviewed as they are received on an ongoing basis.
   The final deadline is <b>15th December</b> but some tracks may close 
-  earlier if they fill up or the respective call for papers
+  earlier if they fill up or the respective call for participation
   specifies an earlier date.
 </p>
 

--- a/content/schedule/tracks.html
+++ b/content/schedule/tracks.html
@@ -22,7 +22,7 @@ categories = [
     <thead>
         <tr>
             <th>Track</th>
-	    <th>Call For<br /> Papers</th>
+	    <th>Call For<br /> Participation</th>
             <th>Rooms</th>
             <% days.each do |d| %>
             <th><%= d[:title] %></th>

--- a/layouts/schedule/track.html
+++ b/layouts/schedule/track.html
@@ -185,7 +185,7 @@
     if cfp
 %>
 <div class="well well-small track-cfp">
-      <p>Read the Call for Papers at <a href="<%= cfp %>"><%= cfp %></a>.</p>
+      <p>Read the Call for Participation at <a href="<%= cfp %>"><%= cfp %></a>.</p>
 </div>
 <% end %>
 


### PR DESCRIPTION
I realized that the website does not always follow the `CfP` == `Call for Participation` naming. Instead, at some locations a call for `papers` has sneaked in. However the recent [news](https://fosdem.org/2023/news/) clearly prefer a call for `participation`. This PR just changes some occurrences of `paper` to keep that style.

Note: The `pentabarf.yml` file still defines a `conference_call_for_papers_url` that I didn't change since that sounded like it'll break things :-). I just changed the text occurrences.