### PR TITLE
Use generic submission link to prevent updating

### DIFF
--- a/content/manuals/program/speaker.md
+++ b/content/manuals/program/speaker.md
@@ -68,7 +68,7 @@ headset
 occasion 
 
 ## Uploading videos
-Videos should be uploaded to https://penta.fosdem.org/submission/FOSDEM22. Click on "Events" in the left menu, select your own event, select "General" tab, scroll down to "Pre-recorded Video Upload URL" and click on "Upload" text.
+Videos should be uploaded to [Penta](https://penta.fosdem.org/submission/). Click on "Events" in the left menu, select your own event, select "General" tab, scroll down to "Pre-recorded Video Upload URL" and click on "Upload" text.
 
 Technical requirements for your presentation video are:
 


### PR DESCRIPTION
Replace the year-specific submission link by a generic one to ensure it stays up to date.