### PR TITLE
Main page beer link to Covid policy page

### DIFF
--- a/layouts/main.html
+++ b/layouts/main.html
@@ -94,7 +94,7 @@ $layout_dateline ||= begin
                                 end
                               end
               {
-                'beer' => nil,
+                'beer' => '/practical/covid/',
               'devrooms' => '/schedule/tracks/',
               'open source' => 'https://en.wikipedia.org/wiki/Open-source_model',
               '8000+ hackers' => nil,


### PR DESCRIPTION
The Covid policy page explains that the beer event is cancelled.
Point the beer link on the main page to the Covid page so people
looking for the beer event can understand what is going on.
