### PR TITLE
Add description for the Modern Email devroom

### DIFF
--- a/content/schedule/devrooms/modern-email.html
+++ b/content/schedule/devrooms/modern-email.html
@@ -1,0 +1,5 @@
+<p>Email is the workhorse of digital communication. The new Modern Email devroom brings together users and developers, and gives projects a podium: client/server/library implementations, protocol standardization efforts, security aspects, and more!</p>
+
+<p>The day will be packed with interesting talks. Grouped by topic, each with a small room-switching break.</p>
+
+<p>See <a href="https://github.com/modern-email/FOSDEM-24">https://github.com/modern-email/FOSDEM-24</a> for details.</p>


### PR DESCRIPTION
The goal is to show this text at https://fosdem.org/2024/schedule/track/modern-email/.

I don't know how the "slug" is resolved, and whether "modern-email" is the right choice, or should be "modern_email".
