### PR TITLE
mobile: Fosdem.app (iOS)

### DIFF
--- a/content/schedule/mobile.html
+++ b/content/schedule/mobile.html
@@ -25,6 +25,10 @@ Ways to have the schedule with you at all times, without wasting trees:
     <a href="https://wilmer.gaa.st/main.php/giggity.html">Website and source code</a>,<br />
     Available from <a href="https://play.google.com/store/apps/details?id=net.gaast.giggity">Google Play</a> and <a href="https://f-droid.org/en/packages/net.gaast.giggity/">F-Droid</a>.<br />
 </li>
+<li><b>iOS: FOSDEM.app</b><br />
+    <a href="https://github.com/mttcrsp/fosdem">Source code</a>,<br />
+    Available from <a href="https://apps.apple.com/app/fosdem-app/id1513719757">the Apple App Store</a>.<br />
+</li>
 <li><b>KDE Plasma: Kongress</b><br />
     <a href="https://invent.kde.org/utilities/kongress">Source code</a><br />
     Available from <a href="https://kdebuild.manjaro.org/images/">Manjaro</a>, <a href="https://postmarketos.org/">postmarketOS</a>, <a href="https://flathub.org/apps/details/org.kde.kongress">Flathub</a> and more.<br />


### PR DESCRIPTION
This PR updates the [Mobile Schedule Apps](https://fosdem.org/2024/schedule/mobile/) page to include a link to [FOSDEM.app](https://github.com/mttcrsp/fosdem), an iOS schedule app I have been maintaining for the last few years that supports the 2024 schedule.