### PR TITLE
fix video source url for mp4 video element the event pages

### DIFF
--- a/layouts/schedule/event.html
+++ b/layouts/schedule/event.html
@@ -77,7 +77,7 @@
 <div class="video">
   <video preload="none" controls="controls">
     <source src="<%= url %>" type='video/webm; codecs="av01.0.08M.08.0.110.01.01.01.0"' />
-    <source src="<%= url.gsub(/\.webm$/, ".mp4") %>" type='video/mp4' />
+    <source src="<%= url.gsub(/\.av1\.webm$/, ".mp4") %>" type='video/mp4' />
   </video>
 </div>
 <% end %>


### PR DESCRIPTION
the webm urls appear to end in ".av1.webm", and the mp4 urls end in just ".mp4".

i had av1 disabled in my firefox (i believe related to cpu usage due to software decoding). when trying to play the video on the event page, i get an error. the wrong mp4 url is loaded, it returns a 404.

the mp4 video recording link in the Links section already seems correct.
