### PR TITLE
Build the website in github actions

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -1,0 +1,41 @@
+name: Build FOSDEM site
+
+on:
+  push:
+    branches:
+      - master
+      - gha
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Copy test penta/pretalx export
+        run: |
+          mv sample/export .
+      - name: Ensure pdf_grid is set to false in config.yaml
+        run: |
+          sed -i '/^pdf_grid/d' config.yaml
+          echo "pdf_grid: false" >> config.yaml
+
+
+      - name: Run nanoc build in docker
+        uses: docker://ghcr.io/johanvdw/fosdem-website
+        with:
+          entrypoint: /bin/sh
+          args: -c "bundle install && nanoc"
+
+      # Step 5: Upload the 'output' directory as an artifact
+      - name: Upload output directory
+        uses: actions/upload-artifact@v4
+        with:
+          name: nanoc-output
+          path: output
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,19 +8,17 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -yq \
       krb5-user
 
 # Copy the Gemfile in and bundle, so we have the dependencies cached
-ADD Gemfile .
-ADD Gemfile.lock .
+COPY Gemfile Gemfile.lock .
 RUN gem install bundler:1.17.3 && bundle install
 
 # Set encoding to prevent nanoc exploding
 ENV LANG=C.UTF-8
 ENV APP_DIR=/usr/src/app
 
-# Copy the rest of the app in
-ADD . $APP_DIR
-
 # Port 3000 is used for `nanoc view`
 EXPOSE 3000
 WORKDIR $APP_DIR
 ENTRYPOINT ["bundle", "exec"]
+
+LABEL org.opencontainers.image.source https://github.com/FOSDEM/website
 CMD ['nanoc', 'view']


### PR DESCRIPTION
Idea is that more people can contribute to the website and build without having to setup a whole pipeline. Once pretalx publishes its yaml we can have a second test on that instead of the demo version.

The container was built and pushed to my package repository because it seems github does not allow pushing packages when using fine grained pats ( https://github.com/github/roadmap/issues/558 ). If someone can get it at FOSDEM, that seems a better place.

Example output: https://github.com/FOSDEM/website/actions/runs/10930212380