### PR TITLE
Disregard case when sorting devrooms on schedule page

### DIFF
--- a/content/schedule.html
+++ b/content/schedule.html
@@ -225,7 +225,7 @@ columns = 3
 <div class="container-fluid">
     <div class="row-fluid">
         <% columns = [columns, devrooms.size].min %>
-        <% devrooms.sort_by{|x| x[:title]}.each_slice((devrooms.size / columns).ceil) do |list| %>
+        <% devrooms.sort_by{|x| x[:title].downcase}.each_slice((devrooms.size / columns).ceil) do |list| %>
         <div class="span<%= 9 / columns %>">
             <ul>
                 <% list.each do |t| %>


### PR DESCRIPTION
The version currently online displays "eBPF" at the end of the list of devrooms on the chedule page, because it starts with a lowercase, making it harder to find in the list. Instead, make devroom sorting case-insensitive. This is consistent with how the lists for the Stands, BoFs, and Junior events are generated on the same page.