### PR TITLE
adding clarity for email addresses

### DIFF
--- a/content/manuals/program/devroom.md
+++ b/content/manuals/program/devroom.md
@@ -24,8 +24,8 @@ Please try to remember to send individual requests to that address and
 keep this devroom-manager mailing list for messages and discussion that
 may be of interest to other devrooms.
 
-Secondly, we create mail aliases &lt;room&gt;-devroom-manager@fosdem.org that
-provide a convenient way for us to contact each other, for example
+Secondly, we create mail aliases &lt;room&gt;-devroom-manager@fosdem.org or &lt;room&gt;-devroom-manager@fosdem.org that
+provides a convenient way for us to contact each other, for example
 to discuss moving proposed talks between devrooms.  Note that these
 alias expansions also include devrooms@fosdem.org.
 Again, please make sure you read those messages.


### PR DESCRIPTION
Looking at [the report](https://pretalx.fosdem.org/orga/event/fosdem-2025/p/devroom-report/) in Pretalx, sometimes the devroom mailing address becomes `<room>-devroom-manager@fosdem.org `and sometimes it becomes `<room>-devroom-managers@fosdem.org`. Just adding that it could be either one here.

Also fixing the tense of provide.