### PR TITLE
Read devroom description from pretalx

### DIFF
--- a/layouts/schedule/track.html
+++ b/layouts/schedule/track.html
@@ -160,11 +160,11 @@
 <% end %>
 
 <%
-    description = $item_by_id["/schedule/devrooms/#{item[:slug]}/"]
+    description = Kramdown::Document.new(item[:description], :auto_ids => false).to_html
     if description
 %>
 <div class="well well-small track-description">
-    <%= description.compiled_content %>
+    <%= description %>
 </div>
 <% end %>
 


### PR DESCRIPTION
This parses the description as markdown, so people can use nicer formatting without allowing arbitrary html.

Depends on https://github.com/FOSDEM/pretalx-integration/pull/63.