### PR TITLE
Add slug to speakers xml export (proposal)

### DIFF
--- a/content/schedule/pentabarf.xml
+++ b/content/schedule/pentabarf.xml
@@ -68,7 +68,7 @@ xml.schedule do
               xml.feedback_url event[:feedback_url]
               xml.persons do
                 event[:speakers].map(&$to_speaker).each do |speaker|
-                  xml.person( speaker[:name], {:id=>speaker[:person_id]} )
+                  xml.person( speaker[:name], {:id=>speaker[:person_id],:slug=>speaker[:slug]} )
                 end
               end
               xml.attachments do


### PR DESCRIPTION
Adds the slug of speakers to the xml export. Can be used to fetch user information on the website for apps.
Example file for 2024:
[schedule.xml.zip](https://github.com/user-attachments/files/17894549/schedule.xml.zip)

speakers can be reached by this slug:
https://fosdem.org/<edition>/schedule/speaker/<slug>

This is just a proposal, we might as well add all speaker information inside the xml as well under a new section. Not sure what would be most appropriate.