### PR TITLE
Correct event count on schedule.html page

### DIFF
--- a/content/schedule.html
+++ b/content/schedule.html
@@ -55,7 +55,7 @@ columns = 3
 <p>
   FOSDEM is a rather busy conference.
 <% if speakers.size > 100 and events.size > 100 %>
-  This edition features <%= speakers.size %> speakers, <%= events.size + 1 %>
+  This edition features <%= speakers.size %> speakers, <%= events.size %>
   events, and <%= tracks.size %> tracks.
 <% else %>
   Recent editions featured 400+ speakers, 500+ events and a wealth of tracks.


### PR DESCRIPTION
It seems that the fix 136e6880fb14b7f39def2f9f4b35c35e3522913b from 2016 is no longer required (compared the count in export xml)

Fixes #237