### PR TITLE
devrooms: Add blurb for eBPF devroom

### DIFF
--- a/content/schedule/devrooms/ebpf.html
+++ b/content/schedule/devrooms/ebpf.html
@@ -1,0 +1,24 @@
+<p>
+  eBPF is a technology that runs sandboxed programs in a privileged context,
+  such as the operating system kernel. Use it to safely and efficiently extend
+  the capabilities of the kernel, without changing kernel source code or
+  loading kernel modules. Originally developed for the Linux kernel, eBPF now
+  runs on other platforms, too. For more information on eBPF, see the
+  <a href="https://ebpf.io">https://ebpf.io</a> website, or the
+  <a href="https://en.wikipedia.org/wiki/EBPF">eBPF page on Wikipedia</a>.
+</p>
+
+<p>
+  FOSDEM'25 hosts the first eBPF devroom. The devroom covers all things related
+  to eBPF: features development, new runtimes, deep-dives on existing features,
+  eBPF toolchain and libraries, and more. Come and learn about eBPF, and meet
+  the community!
+</p>
+
+<p>
+  For more information on the topics of interest, see the
+  <a href="https://ebpf.io/fosdem-2025.html">call for participation</a>.
+  The official communication channel for the devroom is the
+  <a href="https://lists.fosdem.org/listinfo/ebpf-devroom">ebpf-devroom
+  mailing list</a>.
+</p>


### PR DESCRIPTION
Add a blurb for the eBPF devroom, following the instructions from https://fosdem.org/2025/manuals/program/devroom/#reviewing-talks.
