### PR TITLE
Do not capitalize h1 tags by default

### DIFF
--- a/content/assets/style/parts/010_design.css
+++ b/content/assets/style/parts/010_design.css
@@ -7,7 +7,6 @@ body{
 }
 
 h1 {
-	text-transform: capitalize;
 	text-align: center;
 }
 


### PR DESCRIPTION
Some devroom names might start with a lowercase letter. The current h1 formatting leads to incorrect titles in /schedule/track/$devroom. One example of this is: https://fosdem.org/2025/schedule/track/ebpf/, where the title is incorrectly shown as "EBPF" (versus "eBPF", which is the devroom name in the track list). This behaviour was introduced in #263 and is fairly recent. I am not fully aware if this might break other h1 formatting (like some stuff in layouts/main.html).