### PR TITLE
Use matrix.to as URL

### DIFF
--- a/content/manuals/program/speaker.md
+++ b/content/manuals/program/speaker.md
@@ -155,7 +155,7 @@ Q&A sessions outside of the presentation time. Remember, your Q&A can continue
 in a separate live video conference after your talk has ended.
 
 ## Further support
-* [FOSDEM matrix channel](https://matrix.to/#/%23fosdem:fosdem.org)
+* `#fosdem:matrix.org` on Matrix: [desktop web (with video player)](https://chat.fosdem.org/#/room/#fosdem:matrix.org), [native apps for mobile and desktop (text-only)](https://matrix.to/#/%23fosdem:fosdem.org)
 * [#fosdem on Libera.Chat](ircs://irc.libera.chat:6697/fosdem)
 * contact FOSDEM at speakers@fosdem.org
 

--- a/content/manuals/program/speaker.md
+++ b/content/manuals/program/speaker.md
@@ -155,7 +155,7 @@ Q&A sessions outside of the presentation time. Remember, your Q&A can continue
 in a separate live video conference after your talk has ended.
 
 ## Further support
-* [FOSDEM matrix channel](https://chat.fosdem.org/#/room/#fosdem:matrix.org)
+* [FOSDEM matrix channel](https://matrix.to/#/%23fosdem:fosdem.org)
 * [#fosdem on Libera.Chat](ircs://irc.libera.chat:6697/fosdem)
 * contact FOSDEM at speakers@fosdem.org
 


### PR DESCRIPTION
Given: Someone who has installed Element Desktop, or Element X on their phone. With the previous link they're given a complex web app that will load in 30 seconds with a preview shown after another minute. Even then, there's no clear way to go from here to joining with your app.

Once it fully loads, one can (if you happen to know), click on the Info icon for the channel, and then click the Share button. That still won't do it, but it gives you the matrix.to URL in plain text which you could then render a link, or send to yourself, or paste in the address bar, after which a button will appear to Open in Element.

I suggest we link to this page directly. The same page will link to the Element Web experience of you don't have an app/account yet.