### PR TITLE
Avoid looking like an installable PWA

### DIFF
--- a/content/manifest.json
+++ b/content/manifest.json
@@ -23,5 +23,5 @@
 		}
 	],
 	"theme_color": "#af2c93",
-	"display": "standalone"
+	"display": "browser"
 }


### PR DESCRIPTION
Based on my reading of https://web.dev/articles/install-criteria#criteria, this should prevent an install prompt in "helpful" browsers.