### PR TITLE
Rework LMAX Group Sponsor Description to be FOSDEM-Specific

### DIFF
--- a/content/sponsors/lmax.markdown
+++ b/content/sponsors/lmax.markdown
@@ -5,16 +5,14 @@ cornerstone: false
 ---
 
 As a leading player in global FX and digital assets, LMAX Group is shaping the
-future of capital markets. Our rapidly expanding global institutional and
-professional client base is a testament to our distinctive business model that
-delivers efficient market structure and transparent, precise, consistent
-execution to all market participants. LMAX Group operates three established
-regulated businesses – LMAX Exchange, LMAX Global and LMAX Digital.
-
-Servicing funds, banks, asset managers, retail brokerages and buy-side
-institutions in over 100 countries, LMAX Group has developed a strong global
-presence with offices in 9 countries. The Group builds and runs its own high
-performance, ultra-low latency global exchange infrastructure, which includes
-matching engines in London, New York, Tokyo and Singapore.
+future of capital markets by operating high-performance, ultra-low latency global
+exchange infrastructure. Our commitment to the open source ecosystem is demonstrated by
+our active contribution to the ecosystem, including the in-house projects like
+[Disruptor](https://github.com/lmax-exchange/disruptor/) and
+[Simple-DSL](https://github.com/LMAX-Exchange/Simple-DSL/), and by our
+practice of feeding back code changes and providing commercial support to the open
+source projects we rely on. Driven by a strong culture of technical excellence, we
+are a great place to work for engineers passionate about building complex,
+high-throughput systems for our global client base.
 
 LMAX Group supports the event financially.


### PR DESCRIPTION
Our Marketing Team have asked to replace the generic wording on the site with something more OSS and FOSDEM specific.