### PR TITLE
Fix: Update video playback sizing to full width (fixes #296 )

### DIFF
--- a/layouts/schedule/event.html
+++ b/layouts/schedule/event.html
@@ -59,7 +59,7 @@
     url = video
 %>
 <div class="video">
-  <video preload="none" controls="controls" width="75%">
+  <video preload="none" controls="controls" width="100%">
     <source src="<%= url %>" type='video/webm; codecs="av01.0.08M.08.0.110.01.01.01.0"' />
     <source src="<%= url.gsub(/\.av1\.webm$/, ".mp4") %>" type='video/mp4' />
   </video>


### PR DESCRIPTION
This PR resolves the issue with video playback sizing being limited to 75% of the available width (fixes #296 )
The styling is updated so that videos now utilize the full width (100%) as intended.

This is a clean version of the previous PR, containing only the functional change, without any formatting modifications.

Previous PR for reference: #298 