### PR TITLE
📝 devrooms(distributions): Update description text for 2026

### DIFF
--- a/content/schedule/devrooms/distributions.html
+++ b/content/schedule/devrooms/distributions.html
@@ -1,0 +1,7 @@
+<p>The Distributions DevRoom returns in-person to FOSDEM for a full day of Linux distro-related content in Brussels on Sunday, February 1st, 2026.</p>
+
+<p>Linux distributions are the backbone of digital infrastructure. They are among the most historic Free and Open Source Software communities, and they are increasingly relevant as the core of containerized workloads. They are the face of open source for users and administrators.</p>
+
+<p>Distributions are a crucial piece of the pipeline for many upstream projects. They ensure that various versions of upstream software work well together, whether in fast-moving distributions that deliver the latest features, or in long-term-support distributions that often outlive the upstream software versions.</p>
+
+<p>This DevRoom provides a unique home for several Linux distribution communities to share ideas, and to have conversations with the upstream projects they package. The distributions DevRoom is a historic open forum that is unique to FOSDEM in making a space for all of our communities to share and learn from each other.</p>


### PR DESCRIPTION
This commit pulls the description text from the 2025 Distributions DevRoom for the FOSDEM website. This version does carry some updates from 2025, but the updates made in this commit were directly pulled from our FOSDEM 2026 proposal for the DevRooms.

CC: @shaunix @ilvipero @lucaskanashiro