### PR TITLE
c/s/promote.html: Fix image link with baseurl

### DIFF
--- a/content/support/promote.html
+++ b/content/support/promote.html
@@ -31,7 +31,7 @@ them to promote the event</p>
 	  <td>
             <p>Link: <a href="<%= badge.path %>"><%= badge.path %></a></p>
             <p>HTML markup:<br/>
-            <code>&lt;a href="https://fosdem.org"&gt;&lt;img src="<%= badge.path %>" alt="FOSDEM"/&gt;&lt;/a&gt;</code></p>
+            <code>&lt;a href="https://fosdem.org"&gt;&lt;img src="https://fosdem.org<%= badge.path %>" alt="FOSDEM"/&gt;&lt;/a&gt;</code></p>
           </td>
         </tr>
       <% end %>


### PR DESCRIPTION
Generated html did not contain the base url:

    <a ...><img src="/2026/support/promote/wide.png" alt="FOSDEM"/></a>

By the way let me share the mardown syntax I used:

    [![FOSDEM2026](
    https://fosdem.org/2026/support/promote/wide.png
    )](
    https://fosdem.org/2026
    )