### PR TITLE
updated routing and textfile handling for the json assets file

### DIFF
--- a/Rules
+++ b/Rules
@@ -331,6 +331,10 @@ route '/404/' do
   "/404.html"
 end
 
+route '/.well-known/assetlinks/' do
+  "/.well-known/assetlinks.json"
+end
+
 # send this one into oblivion, its compiled content is included in
 # layouts/default.html, but is not to be rendered as a file of its
 # own into output

--- a/config.yaml
+++ b/config.yaml
@@ -34,7 +34,7 @@ pdf_grid: true
 # A list of file extensions that nanoc will consider to be textual rather than
 # binary. If an item with an extension not in this list is found,  the file
 # will be considered as binary.
-text_extensions: [ 'css', 'erb', 'haml', 'htm', 'html', 'js', 'less', 'markdown', 'md', 'php', 'rb', 'sass', 'scss', 'txt', 'xhtml', 'xml', 'coffee', 'ics' ]
+text_extensions: [ 'css', 'erb', 'haml', 'htm', 'html', 'js', 'less', 'markdown', 'md', 'php', 'rb', 'sass', 'scss', 'txt', 'xhtml', 'xml', 'coffee', 'ics' , 'json' ]
 
 # The path to the directory where all generated files will be written to. This
 # can be an absolute path starting with a slash, but it can also be path


### PR DESCRIPTION
updated rules to send .well-known to the root dir withouth $prefix beeing used. added json as text extensions as we mangle all non text files in our Rules file to add the $prefix