### PR TITLE
Update matrix.to link to use chat.fosdem.org; point to sign up on chat.fosdem.org

### DIFF
--- a/content/contact.html
+++ b/content/contact.html
@@ -10,8 +10,16 @@ title: Contact
 </p>
 
 <p>
-  You may also join us for a chat in
-  <a href="https://matrix.to/#/#fosdem:matrix.org">the #fosdem:matrix.org matrix room</a>.
+  You may also join us for a chat at any time in
+  <a href="https://matrix.to/#/#fosdem:fosdem.org?web-instance[element.io]=chat.fosdem.org">the #fosdem:fosdem.org matrix room</a>.
+</p>
+
+<p>
+  During the event, you can join real-time discussions and watch talks live on matrix!
+  See the matrix space at 
+  <a href="https://matrix.to/#/#fosdem-space:fosdem.org?web-instance[element.io]=chat.fosdem.org">#fosdem-space:fosdem.org</a>.
+  Don't have a matrix account yet? Create one for free at
+  <a href="https://chat.fosdem.org/#/room/#fosdem:fosdem.org">chat.fosdem.org</a>.
 </p>
 
 


### PR DESCRIPTION
This PR updates the Contact page such that:

- The link to #fosdem:fosdem.org will encourage the user to use chat.fosdem.org instead of app.element.io (and thus matrix.org). If the user already has a matrix account, the matrix.to link will work best for them.
- Add a link to the current FOSDEM Space.
- Encourage the user to sign up on chat.fosdem.org if they don't already have a matrix account.