### PR TITLE
donate: add name to wire transfer information

### DIFF
--- a/content/support/donate.html
+++ b/content/support/donate.html
@@ -21,6 +21,7 @@ navtitle: Donate
 <h3>Wire transfer</h3>
 <p>
   <ul>
+    <li><b>Name:</b> FOSDEM VZW</li>
     <li><b>IBAN:</b> BE50 0016 8930 5318</li>
     <li><b>BIC:</b> GEBABEBB</li>
   </ul>


### PR DESCRIPTION
seems good practice to communicate, especially since the introduction of vop in the sepa:
https://www.europeanpaymentscouncil.eu/what-we-do/other-schemes/verification-payee

i've added the name that according to my bank, the fosdem bank says is the correct name.